### PR TITLE
[semver:patch] Make running `go generate` and `go get` optional during builds

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -6,6 +6,14 @@ parameters:
     description: The value of the CGO_ENABLED environment variable to use
     type: string
     default: "0"
+  run_generate:
+    description: Whether to run `go generate` prior to `go build`
+    type: boolean
+    default: true
+  run_get:
+    description: Whether to run `go get` prior to `go build`
+    type: boolean
+    default: true
 
 steps:
   - cache-modules
@@ -17,5 +25,7 @@ steps:
         GOARCH: "amd64"
         GOOS: "linux"
         GOPRIVATE: "github.com/AchievementNetwork/*"
+        GORUNGENERATE: <<# parameters.run_generate >>yes<</ parameters.run_generate>>
+        GORUNGET: <<# parameters.run_get >>yes<</ parameters.run_get>>
       command: |
         make build

--- a/src/examples/go-build-parameters-job.yml
+++ b/src/examples/go-build-parameters-job.yml
@@ -1,0 +1,18 @@
+description: >
+  Example of a job that will build Go executables
+  This job shows optional parameters that may be set during the build
+
+usage:
+  version: 2.1
+
+  orbs:
+    go: achievementnetwork/go@1.1.0
+
+  jobs:
+    go-build:
+      executor: go/default
+      steps:
+        - go/build:
+            cgo_enabled: "1"
+            run_generate: false
+            run_get: false

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -14,7 +14,17 @@ parameters:
     description: The version of GoLang to use
     type: string
     default: '1.15'
+  run_generate:
+    description: Whether to run `go generate` prior to `go build`
+    type: boolean
+    default: true
+  run_get:
+    description: Whether to run `go get` prior to `go build`
+    type: boolean
+    default: true
 
 steps:
   - build:
       cgo_enabled: << parameters.cgo_enabled >>
+      run_generate: << parameters.run_generate >>
+      run_get: << parameters.run_get >>


### PR DESCRIPTION
* Introduce parameters to the build command and job which allow a project to be configured so that `go generate` and/or `go get` are not run during the build phase.  This exposes new functionality added to common make.
* Add example showing the parameters being used